### PR TITLE
Fixed `sol_eval` crash where `answer_info`'s ast isn't a `float`

### DIFF
--- a/packages/remotes/tests/test_rewards.py
+++ b/packages/remotes/tests/test_rewards.py
@@ -91,6 +91,12 @@ if TYPE_CHECKING:
             0.0,
             id="unreasonable-molecule-failure",
         ),
+        pytest.param(
+            "CC(C)(C)Cc1nc(Br)c(S(C)(=O)=O)n1Cc1ccc(-c2ccccc2-c2nn[nH]n2)cc1",
+            "('scaffold', 'c1ccc(-c2nn[nH]n2)c(-c2ccc(Cn3ccnc3)cc2)c1', '-7.790801048278809', 'decrease')",  # noqa: E501
+            0.0,
+            id="eval-has-str-value",
+        ),
     ],
 )
 def test_oracle_solubility_eval(

--- a/src/ether0/rewards.py
+++ b/src/ether0/rewards.py
@@ -481,8 +481,9 @@ def oracle_solubility_eval(
         RewardReason.INVALID_MOL.set_reason(metadata)
         return 0.0
 
-    y_args: tuple[str, str | list[str], float, str] = ast.literal_eval(y)
-    constraint_type, constraint_data, target = y_args[:3]
+    y_args: tuple[str, str | list[str], float | str, str] = ast.literal_eval(y)
+    constraint_type, constraint_data = y_args[:2]
+    target = float(y_args[2])
     # Unused: direction = y_args[3]  # noqa: ERA001
 
     ref_mol: Chem.Mol | None = None


### PR DESCRIPTION
This was in our private repo, but when opening I thought I could remove a `float`-cast. Turns out this was a mistake...