### PR TITLE
Reusing `extract_answer_loose` in `accuracy_reward`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ from lmi import LiteLLMModel
 from tqdm.asyncio import tqdm_asyncio as asyncio
 
 from ether0.data import get_problem_category
-from ether0.model_prompts import LOOSE_XML_ANSWER_USER_PROMPT
-from ether0.rewards import accuracy_reward
+from ether0.model_prompts import LOOSE_XML_ANSWER_USER_PROMPT, extract_answer_loose
+from ether0.models import RewardFunctionInfo
+from ether0.rewards import EVAL_FUNCTIONS
 
 # Add LLM prompt of your making to the dataset
 test_ds = load_dataset("futurehouse/ether0-benchmark", split="test").map(
@@ -179,17 +180,17 @@ results = await asyncio.gather(
 )
 
 # Compute rewards
-rewards = accuracy_reward(
-    completions=[result[0].text for result in results],
-    solution=[row["solution"] for row in test_ds],
-    reasoning=False,
-    test=True,  # Use test flag for third party LLMs using loose prompt
-)
-
-# Aggregate rewards by problem category for understandability
 per_category_rewards = defaultdict(list)
-for prob_type, reward in zip(test_ds["problem_type"], rewards, strict=True):
-    per_category_rewards[get_problem_category(prob_type)].append(reward)
+for row, result in zip(test_ds, results, strict=True):
+    # NOTE: you can also use `ether0.rewards.accuracy_reward`,
+    # but we decided to go a bit "lower level" for this demo
+    reward_info = RewardFunctionInfo.model_validate(row["solution"])
+    yhat = extract_answer_loose(result[0].text)
+    reward = EVAL_FUNCTIONS[reward_info.fxn_name](
+        yhat=yhat, y=reward_info.answer_info, test=True
+    )
+    per_category_rewards[get_problem_category(reward_info.problem_type)].append(reward)
+
 for category, rewards in sorted(per_category_rewards.items()):
     print(
         f"In category {category!r} of {len(rewards)} questions,"


### PR DESCRIPTION
https://github.com/Future-House/ether0/pull/6 forgot to use `test` arg, and when adding it just now, I realized:

1. `accuracy_reward` should reuse `extract_answer_loose` for `test`
    - This was due to the organic nature of our internal code base as many scripts, arising without a DRY'ing out
3. The baselines demo could use `accuracy_reward` directly